### PR TITLE
Fixes for 2.002 plus some improvements

### DIFF
--- a/fc_button.js
+++ b/fc_button.js
@@ -435,7 +435,7 @@ function FCMenu() {
       subsection.append($('<div>').addClass('listing').html('<b>Max Average Cookie Value:</b> ' + Beautify(cookieValue(maxCookies))));
     }
     subsection.append($('<div>').addClass('listing').html('<b>Max Lucky Cookie Value:</b> ' + Beautify(maxLuckyValue())));
-    subsection.append($('<div>').addClass('listing').html('<b>Cookie Bank Required for Max Lucky:</b> ' + Beautify(maxLuckyValue() * 10)));
+    subsection.append($('<div>').addClass('listing').html('<b>Cookie Bank Required for Max Lucky:</b> ' + Beautify(maxLuckyBank())));
     subsection.append($('<div>').addClass('listing').html('<b>Max Chain Cookie Value:</b> ' + Beautify(calculateChainValue(chainBank(), Game.cookiesPs, (7 - (Game.elderWrath / 3))))));
     subsection.append($('<div>').addClass('listing').html('<b>Cookie Bank Required for Max Chain:</b> ' + Beautify(chainBank())));
     subsection.append($('<div>').addClass('listing').html('<b>Estimated Cookie CPS:</b> ' + Beautify(gcPs(cookieValue(currentCookies)))));

--- a/fc_button.js
+++ b/fc_button.js
@@ -533,7 +533,7 @@ function FCMenu() {
       {name: 'Chain Bank', cost: chainBank(), efficiency: cookieEfficiency(Game.cookies, chainBank())}];
     
     banks.forEach(function(bank) {
-      var deltaCps = effectiveCps(bank.cost) - effectiveCps();
+      var deltaCps = effectiveCps(bank.cost) - effectiveCps(Game.cookies);
       buildTable.append($('<tr><td colspan="2"><b>' + bank.name + (bank.deltaCps === 0 ? ' (*)' : '') + '</b></td><td>' + Beautify(bank.efficiency) + '</td><td>' + Beautify(Math.max(0, bank.cost - Game.cookies)) + '</td><td>' + Beautify(deltaCps) + '</td></tr>'));
     });
     buildTable.append($('<tr><td colspan="5">&nbsp;</td></tr>'));

--- a/fc_button.js
+++ b/fc_button.js
@@ -435,7 +435,7 @@ function FCMenu() {
       subsection.append($('<div>').addClass('listing').html('<b>Max Average Cookie Value:</b> ' + Beautify(cookieValue(maxCookies))));
     }
     subsection.append($('<div>').addClass('listing').html('<b>Max Lucky Cookie Value:</b> ' + Beautify(maxLuckyValue())));
-    subsection.append($('<div>').addClass('listing').html('<b>Cookie Bank Required for Max Lucky:</b> ' + Beautify(maxLuckyValue() * 10)));
+    subsection.append($('<div>').addClass('listing').html('<b>Cookie Bank Required for Max Lucky:</b> ' + Beautify(maxLuckyValue() / 0.15)));
     subsection.append($('<div>').addClass('listing').html('<b>Max Chain Cookie Value:</b> ' + Beautify(calculateChainValue(chainBank(), Game.cookiesPs, (7 - (Game.elderWrath / 3))))));
     subsection.append($('<div>').addClass('listing').html('<b>Cookie Bank Required for Max Chain:</b> ' + Beautify(chainBank())));
     subsection.append($('<div>').addClass('listing').html('<b>Estimated Cookie CPS:</b> ' + Beautify(gcPs(cookieValue(currentCookies)))));

--- a/fc_button.js
+++ b/fc_button.js
@@ -201,11 +201,42 @@ function drawCircles(t_d, x, y) {
         fillStyle: o_draw.c1,
         x: x + maxRadius * 2 + maxWidth / 2 + 35, y: y + heightOffset+15*i_tc,
         text: s_t
-      });   
+      });
       i_tc++;
     }
     i_c++;
   });
+}
+
+function hasBuildingSpecialBuff() {
+  if(Game.hasBuff('High-five') > 0) { return Game.hasBuff('High-five'); }
+  if(Game.hasBuff('Slap to the face') > 0) { return Game.hasBuff('Slap to the face'); }
+  if(Game.hasBuff('Congregation') > 0) { return Game.hasBuff('Congregation'); }
+  if(Game.hasBuff('Senility') > 0) { return Game.hasBuff('Senility'); }
+  if(Game.hasBuff('Luxuriant harvest') > 0) { return Game.hasBuff('Luxuriant harvest'); }
+  if(Game.hasBuff('Locusts') > 0) { return Game.hasBuff('Locusts'); }
+  if(Game.hasBuff('Ore vein') > 0) { return Game.hasBuff('Ore vein'); }
+  if(Game.hasBuff('Cave-in') > 0) { return Game.hasBuff('Cave-in'); }
+  if(Game.hasBuff('Oiled-up') > 0) { return Game.hasBuff('Oiled-up'); }
+  if(Game.hasBuff('Jammed machinery') > 0) { return Game.hasBuff('Jammed machinery'); }
+  if(Game.hasBuff('Juicy profits') > 0) { return Game.hasBuff('Juicy profits'); }
+  if(Game.hasBuff('Recession') > 0) { return Game.hasBuff('Recession'); }
+  if(Game.hasBuff('Fervent adoration') > 0) { return Game.hasBuff('Fervent adoration'); }
+  if(Game.hasBuff('Crisis of faith') > 0) { return Game.hasBuff('Crisis of faith'); }
+  if(Game.hasBuff('Manabloom') > 0) { return Game.hasBuff('Manabloom'); }
+  if(Game.hasBuff('Magivores') > 0) { return Game.hasBuff('Magivores'); }
+  if(Game.hasBuff('Delicious lifeforms') > 0) { return Game.hasBuff('Delicious lifeforms'); }
+  if(Game.hasBuff('Black holes') > 0) { return Game.hasBuff('Black holes'); }
+  if(Game.hasBuff('Breakthrough') > 0) { return Game.hasBuff('Breakthrough'); }
+  if(Game.hasBuff('Lab disaster') > 0) { return Game.hasBuff('Lab disaster'); }
+  if(Game.hasBuff('Righteous cataclysm') > 0) { return Game.hasBuff('Righteous cataclysm'); }
+  if(Game.hasBuff('Dimensional calamity') > 0) { return Game.hasBuff('Dimensional calamity'); }
+  if(Game.hasBuff('Golden ages') > 0) { return Game.hasBuff('Golden ages'); }
+  if(Game.hasBuff('Time jam') > 0) { return Game.hasBuff('Time jam'); }
+  if(Game.hasBuff('Extra cycles') > 0) { return Game.hasBuff('Extra cycles'); }
+  if(Game.hasBuff('Predictable tragedy') > 0) { return Game.hasBuff('Predictable tragedy'); }
+  if(Game.hasBuff('Solar flare') > 0) { return Game.hasBuff('Solar flare'); }
+  if(Game.hasBuff('Eclipse') > 0) { return Game.hasBuff('Eclipse'); }
 }
 
 function updateTimers() {
@@ -216,6 +247,8 @@ function updateTimers() {
     gc_min_delay = (probabilitySpan('golden', Game.shimmerTypes.golden.time, 0.01) - Game.shimmerTypes.golden.time) / maxCookieTime(),
     frenzy_delay = Game.hasBuff('Frenzy') / maxCookieTime(),
     click_frenzy_delay = Game.hasBuff('Click frenzy') / maxCookieTime(),
+    bulding_special_delay = hasBuildingSpecialBuff() / maxCookieTime(),
+    cookie_storm_delay = Game.hasBuff('Cookie storm') / maxCookieTime(),
     decimal_HC_complete = (Game.HowMuchPrestige(Game.cookiesEarned + Game.cookiesReset)%1),
     bankTotal = delayAmount(),
     purchaseTotal = nextPurchase().cost,
@@ -310,6 +343,22 @@ function updateTimers() {
       c1: "rgba(0, 196, 255, 1)",
       name: "Click Frenzy Time",
       display: timeDisplay(Game.hasBuff('Click frenzy')/Game.fps)
+    });
+  }
+  if (bulding_special_delay > 0) {
+    t_draw.push({
+      f_percent: bulding_special_delay,
+      c1: "rgba(0, 196, 255, 1)",
+      name: "Building Special Time",
+      display: timeDisplay(hasBuildingSpecialBuff()/Game.fps)
+    });
+  }
+  if (cookie_storm_delay > 0) {
+    t_draw.push({
+      f_percent: cookie_storm_delay,
+      c1: "rgba(0, 196, 255, 1)",
+      name: "Cookie Storm Time",
+      display: timeDisplay(Game.hasBuff('Cookie storm')/Game.fps)
     });
   }
   if (decimal_HC_complete>0) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -1219,12 +1219,10 @@ function buyFunctionToggle(upgrade) {
 }
 
 function buySanta() {
-  if (Game.LeftBackground) {
-    Game.mouseX = 48;
-    Game.mouseY = Game.LeftBackground.canvas.height-48-24;
-    Game.Click = 1;
-    Game.UpdateSanta();
-    Game.Click = 0;
+  Game.specialTab = 'santa';
+  Game.UpgradeSanta();
+  if (Game.santaLevel + 1 >= Game.santaLevels.length) {
+    Game.ToggleSpecialMenu();
   }
 }
 

--- a/fc_main.js
+++ b/fc_main.js
@@ -529,11 +529,11 @@ function cookieValue(bankAmount, wrathValue, wrinklerCount) {
   // Clot + Ruin
   value -= cookieInfo.clotRuin.odds[wrathValue] * (Math.min(bankAmount * 0.05, cps * 60 * 10 * 0.5) + 13);
   // Lucky
-  value += cookieInfo.lucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20) + 13);
+  value += cookieInfo.lucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 15) + 13);
   // Frenzy + Lucky
-  value += cookieInfo.frenzyLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20 * 7) + 13);
+  value += cookieInfo.frenzyLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 15 * 7) + 13);
   // Clot + Lucky
-  value += cookieInfo.clotLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20 * 0.5) + 13);
+  value += cookieInfo.clotLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 15 * 0.5) + 13);
   // Click
   value += cookieInfo.click.odds[wrathValue] * frenzyCps * luckyMod * 13 * 777;
   // Frenzy + Click
@@ -571,11 +571,11 @@ function cookieStats(bankAmount, wrathValue, wrinklerCount) {
   // Clot + Ruin
   result.clotRuin = -1 * cookieInfo.clotRuin.odds[wrathValue] * (Math.min(bankAmount * 0.05, cps * 60 * 10 * 0.5) + 13);
   // Lucky
-  result.lucky = cookieInfo.lucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20) + 13);
+  result.lucky = cookieInfo.lucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 15) + 13);
   // Frenzy + Lucky
-  result.frenzyLucky = cookieInfo.frenzyLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20 * 7) + 13);
+  result.frenzyLucky = cookieInfo.frenzyLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 15 * 7) + 13);
   // Clot + Lucky
-  result.clotLucky = cookieInfo.clotLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20 * 0.5) + 13);
+  result.clotLucky = cookieInfo.clotLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 15 * 0.5) + 13);
   // Click
   result.click = cookieInfo.click.odds[wrathValue] * frenzyCps * luckyMod * 13 * 777;
   // Frenzy + Click
@@ -641,11 +641,11 @@ function estimatedTimeRemaining(cookies) {
 }
 
 function luckyBank() {
-  return baseCps() * 60 * 20 * 10;
+  return baseCps() * 60 * 15 * 10;
 }
 
 function luckyFrenzyBank() {
-  return baseCps() * 60 * 20 * 7 * 10;
+  return baseCps() * 60 * 15 * 7 * 10;
 }
 
 function chainBank() {
@@ -706,7 +706,7 @@ function weightedCookieValue(useCurrent) {
   }
   if (useCurrent && Game.cookies < maxLuckyValue() * 10) {
     if (lucky_mod) {
-      base_golden -= ((1200 * cps) - Math.min(1200 * cps, Game.cookies * 0.1)) * 0.49 * 0.5 + (maxLuckyValue() - (Game.cookies * 0.1)) * 0.49 * 0.5;
+      base_golden -= ((900 * cps) - Math.min(900 * cps, Game.cookies * 0.1)) * 0.49 * 0.5 + (maxLuckyValue() - (Game.cookies * 0.1)) * 0.49 * 0.5;
     } else {
       base_golden -= (maxLuckyValue() - (Game.cookies * 0.1)) * 0.49;
       base_wrath  -= (maxLuckyValue() - (Game.cookies * 0.1)) * 0.29;
@@ -716,7 +716,7 @@ function weightedCookieValue(useCurrent) {
 }
 
 function maxLuckyValue() {
-  var gcMod = Game.Has('Get lucky') ? 8400 : 1200;
+  var gcMod = Game.Has('Get lucky') ? 6300 : 900;
   return baseCps() * gcMod;
 }
 

--- a/fc_main.js
+++ b/fc_main.js
@@ -641,11 +641,11 @@ function estimatedTimeRemaining(cookies) {
 }
 
 function luckyBank() {
-  return baseCps() * 60 * 15 * 10;
+  return baseCps() * 60 * 15 / 0.15;
 }
 
 function luckyFrenzyBank() {
-  return baseCps() * 60 * 15 * 7 * 10;
+  return baseCps() * 60 * 15 * 7 / 0.15;
 }
 
 function chainBank() {

--- a/fc_main.js
+++ b/fc_main.js
@@ -1505,7 +1505,7 @@ function shouldPopWrinklers() {
 }
 
 function autoFrenzyClick() {
-  if (Game.hasBuff('Click frenzy') > 0 && !FrozenCookies.autoFrenzyBot) {
+  if ((Game.hasBuff('Click frenzy') > 0 || Game.hasBuff('Cursed finger') > 0) && !FrozenCookies.autoFrenzyBot) {
     if (FrozenCookies.autoclickBot) {
       clearInterval(FrozenCookies.autoclickBot);
       FrozenCookies.autoclickBot = 0;

--- a/fc_main.js
+++ b/fc_main.js
@@ -46,7 +46,7 @@ function setOverrides() {
   // Set default values for calculations
   FrozenCookies.hc_gain = 0;
   FrozenCookies.hc_gain_time = Date.now();
-  FrozenCookies.last_gc_state = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * (Game.hasBuff('Click frenzy') ? Game.buffs['Click frenzy'].multClick : 1);
+  FrozenCookies.last_gc_state = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * hasClickFrenzy();
   FrozenCookies.last_gc_time = Date.now();
   FrozenCookies.lastCPS = Game.cookiesPs;
   FrozenCookies.lastCookieCPS = 0;
@@ -261,7 +261,7 @@ function fcReset() {
   }
   Game.oldReset();
   FrozenCookies.frenzyTimes = {};
-  FrozenCookies.last_gc_state = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * (Game.hasBuff('Click frenzy') ? Game.buffs['Click frenzy'].multClick : 1);
+  FrozenCookies.last_gc_state = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * hasClickFrenzy();
   FrozenCookies.last_gc_time = Date.now();
   FrozenCookies.lastHCAmount = Game.HowMuchPrestige(Game.cookiesEarned + Game.cookiesReset + Game.wrinklers.reduce(function(s,w){return s + popValue(w.sucked);}, 0));
   FrozenCookies.lastHCTime = Date.now();
@@ -459,13 +459,16 @@ function probabilitySpan(listType, start, endProbability) {
   return _.sortedIndex(getProbabilityList(listType), (startProbability + endProbability - startProbability * endProbability));
 }
 
+function hasClickFrenzy() {
+  return (Game.hasBuff('Click frenzy') > 0) ? Game.buffs['Click frenzy'].multiclick : (Game.hasBuff('Dragonflight') > 0) ? Game.buffs['Dragonflight'].multClick : 1;
+}
 function baseCps() {
   var frenzyMod = (Game.hasBuff('Frenzy') > 0) ? Game.buffs['Frenzy'].multCpS : 1;
   return Game.cookiesPs / frenzyMod;
 }
 
 function baseClickingCps(clickSpeed) {
-  var clickFrenzyMod = (Game.hasBuff('Click frenzy') > 0) ? Game.buffs['Click frenzy'].multClick : 1;
+  var clickFrenzyMod = hasClickFrenzy();
   var frenzyMod = (Game.hasBuff('Frenzy') > 0) ? Game.buffs['Frenzy'].multCpS : 1;
   var cpc = Game.mouseCps() / (clickFrenzyMod * frenzyMod);
   return clickSpeed * cpc;
@@ -542,7 +545,7 @@ function cookieStats(bankAmount, wrathValue, wrinklerCount) {
   var clickCps = baseClickingCps(FrozenCookies.autoClick * FrozenCookies.cookieClickSpeed);
   var frenzyCps = FrozenCookies.autoFrenzy ? baseClickingCps(FrozenCookies.autoFrenzy * FrozenCookies.frenzyClickSpeed) : clickCps;
   var luckyMod = Game.Has('Get lucky') ? 2 : 1;
-  var clickFrenzyMod = (Game.hasBuff('Click frenzy') > 0) ? Game.buffs['Click frenzy'].multClick : 1
+  var clickFrenzyMod = hasClickFrenzy();
   wrathValue = wrathValue != null ? wrathValue : Game.elderWrath;
   wrinklerCount = wrinklerCount != null ? wrinklerCount : (wrathValue ? 10 : 0);
   var wrinkler = wrinklerMod(wrinklerCount);
@@ -1487,13 +1490,13 @@ function shouldPopWrinklers() {
 }
 
 function autoFrenzyClick() {
-  if (Game.hasBuff('Click frenzy') > 0 && !FrozenCookies.autoFrenzyBot) {
+  if (hasClickFrenzy() > 1 && !FrozenCookies.autoFrenzyBot) {
     if (FrozenCookies.autoclickBot) {
       clearInterval(FrozenCookies.autoclickBot);
       FrozenCookies.autoclickBot = 0;
     }
     FrozenCookies.autoFrenzyBot = setInterval(function(){Game.ClickCookie();}, 1000 / FrozenCookies.frenzyClickSpeed);
-  } else if (Game.hasBuff('Click frenzy') == 0 && FrozenCookies.autoFrenzyBot) {
+  } else if (hasClickFrenzy() == 1 && FrozenCookies.autoFrenzyBot) {
     clearInterval(FrozenCookies.autoFrenzyBot);
     FrozenCookies.autoFrenzyBot = 0;
     if (FrozenCookies.autoClick && FrozenCookies.cookieClickSpeed) {
@@ -1599,7 +1602,7 @@ function autoCookie() {
     if (FrozenCookies.autoBlacklistOff) {
       autoBlacklistOff();
     }
-    var currentFrenzy = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * (Game.hasBuff('Click frenzy') ? Game.buffs['Click frenzy'].multClick : 1);
+    var currentFrenzy = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * hasClickFrenzy());
     if (currentFrenzy != FrozenCookies.last_gc_state) {
       if (FrozenCookies.last_gc_state != 1 && currentFrenzy == 1) {
       	logEvent('GC', 'Frenzy ended, cookie production x1');
@@ -1617,7 +1620,7 @@ function autoCookie() {
           FrozenCookies.hc_gain_time = Date.now();
           FrozenCookies.hc_gain = 0;
         }
-	logEvent('GC', 'Starting ' + (Game.hasBuff('Click frenzy') ? 'Clicking ' : '') + 'Frenzy x' +  currentFrenzy);
+	logEvent('GC', 'Starting ' + ((hasClickFrenzy > 1) ? 'Clicking ' : '') + 'Frenzy x' +  currentFrenzy);
       }
       if (FrozenCookies.frenzyTimes[FrozenCookies.last_gc_state] == null) {
       	FrozenCookies.frenzyTimes[FrozenCookies.last_gc_state] = 0;

--- a/fc_main.js
+++ b/fc_main.js
@@ -1602,7 +1602,7 @@ function autoCookie() {
     if (FrozenCookies.autoBlacklistOff) {
       autoBlacklistOff();
     }
-    var currentFrenzy = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * hasClickFrenzy());
+    var currentFrenzy = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * hasClickFrenzy();
     if (currentFrenzy != FrozenCookies.last_gc_state) {
       if (FrozenCookies.last_gc_state != 1 && currentFrenzy == 1) {
       	logEvent('GC', 'Frenzy ended, cookie production x1');

--- a/fc_main.js
+++ b/fc_main.js
@@ -49,6 +49,7 @@ function setOverrides() {
   FrozenCookies.last_gc_state = (Game.hasBuff('Frenzy') ? Game.buffs['Frenzy'].multCpS : 1) * (Game.hasBuff('Click frenzy') ? Game.buffs['Click frenzy'].multClick : 1);
   FrozenCookies.last_gc_time = Date.now();
   FrozenCookies.lastCPS = Game.cookiesPs;
+  FrozenCookies.lastBaseCPS = Game.cookiesPs;
   FrozenCookies.lastCookieCPS = 0;
   FrozenCookies.lastUpgradeCount = 0;
   FrozenCookies.currentBank = {'cost': 0, 'efficiency' : 0};
@@ -268,6 +269,7 @@ function fcReset() {
   FrozenCookies.maxHCPercent = 0;
   FrozenCookies.prevLastHCTime = Date.now();
   FrozenCookies.lastCps = 0;
+  FrozenCookies.lastBaseCps = 0;
   FrozenCookies.trackedStats = [];
   updateLocalStorage();
   recommendationList(true);
@@ -460,8 +462,16 @@ function probabilitySpan(listType, start, endProbability) {
 }
 
 function baseCps() {
-  var frenzyMod = (Game.hasBuff('Frenzy') > 0) ? Game.buffs['Frenzy'].multCpS : 1;
-  return Game.cookiesPs / frenzyMod;
+  var buffMod = 1;
+  for (var i in Game.buffs) {
+    if (typeof Game.buffs[i].multCpS != 'undefined') buffMod *= Game.buffs[i].multCpS;
+  }
+  if (buffMod === 0) {
+    return FrozenCookies.lastBaseCPS;
+  }
+  var baseCPS = Game.cookiesPs / buffMod;
+  FrozenCookies.lastBaseCPS = baseCPS;
+  return baseCPS;
 }
 
 function baseClickingCps(clickSpeed) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -897,12 +897,18 @@ function upgradeStats(recalculate) {
 
 function isUnavailable(upgrade, upgradeBlacklist) {
   var result = false;
+
   var needed = unfinishedUpgradePrereqs(upgrade);
   result = result || !upgrade.unlocked && !needed;
   result = result || (upgradeBlacklist === true);
   result = result || _.contains(upgradeBlacklist, upgrade.id);
   result = result || (needed && _.find(needed, function(a){return a.type == "wrinklers"}) != null);
   result = result || (upgrade.season && !haveAll(Game.season));
+
+  if (upgrade.id == 331) {
+    result = true; // blacklist golden switch from being used, until proper logic can be implemented
+  }
+
   return result;
 }
 
@@ -1524,7 +1530,8 @@ function autoCookie() {
   if (!FrozenCookies.processing && !Game.OnAscend && !Game.AscendTimer) {
     FrozenCookies.processing = true;
     var currentHCAmount = Game.HowMuchPrestige(Game.cookiesEarned + Game.cookiesReset + Game.wrinklers.reduce(function(s,w){return s + popValue(w.sucked);}, 0));
-    if (FrozenCookies.lastHCAmount < currentHCAmount) {
+
+    if (Math.floor(FrozenCookies.lastHCAmount) < Math.floor(currentHCAmount)) {
       var changeAmount = currentHCAmount - FrozenCookies.lastHCAmount;
       FrozenCookies.lastHCAmount = currentHCAmount;
       FrozenCookies.prevLastHCTime = FrozenCookies.lastHCTime;

--- a/fc_main.js
+++ b/fc_main.js
@@ -460,8 +460,13 @@ function probabilitySpan(listType, start, endProbability) {
 }
 
 function hasClickFrenzy() {
-  return (Game.hasBuff('Click frenzy') > 0) ? Game.buffs['Click frenzy'].multiclick : (Game.hasBuff('Dragonflight') > 0) ? Game.buffs['Dragonflight'].multClick : 1;
+  var ret = 1
+  for (var i in Game.buffs) {
+    if (typeof Game.buffs[i].multClick != 'undefined') ret*=Game.buffs[i].multClick;
+  }
+  return ret;
 }
+
 function baseCps() {
   var frenzyMod = (Game.hasBuff('Frenzy') > 0) ? Game.buffs['Frenzy'].multCpS : 1;
   return Game.cookiesPs / frenzyMod;

--- a/fc_main.js
+++ b/fc_main.js
@@ -521,11 +521,11 @@ function cookieValue(bankAmount, wrathValue, wrinklerCount) {
   // Clot + Ruin
   value -= cookieInfo.clotRuin.odds[wrathValue] * (Math.min(bankAmount * 0.05, cps * 60 * 10 * 0.5) + 13);
   // Lucky
-  value += cookieInfo.lucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20) + 13);
+  value += cookieInfo.lucky.odds[wrathValue] * (Math.min(bankAmount * 0.15, cps * 60 * 15) + 13);
   // Frenzy + Lucky
-  value += cookieInfo.frenzyLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20 * 7) + 13);
+  value += cookieInfo.frenzyLucky.odds[wrathValue] * (Math.min(bankAmount * 0.15, cps * 60 * 15 * 7) + 13);
   // Clot + Lucky
-  value += cookieInfo.clotLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20 * 0.5) + 13);
+  value += cookieInfo.clotLucky.odds[wrathValue] * (Math.min(bankAmount * 0.15, cps * 60 * 15 * 0.5) + 13);
   // Click
   value += cookieInfo.click.odds[wrathValue] * frenzyCps * luckyMod * 13 * 777;
   // Frenzy + Click
@@ -563,11 +563,11 @@ function cookieStats(bankAmount, wrathValue, wrinklerCount) {
   // Clot + Ruin
   result.clotRuin = -1 * cookieInfo.clotRuin.odds[wrathValue] * (Math.min(bankAmount * 0.05, cps * 60 * 10 * 0.5) + 13);
   // Lucky
-  result.lucky = cookieInfo.lucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20) + 13);
+  result.lucky = cookieInfo.lucky.odds[wrathValue] * (Math.min(bankAmount * 0.15, cps * 60 * 15) + 13);
   // Frenzy + Lucky
-  result.frenzyLucky = cookieInfo.frenzyLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20 * 7) + 13);
+  result.frenzyLucky = cookieInfo.frenzyLucky.odds[wrathValue] * (Math.min(bankAmount * 0.15, cps * 60 * 15 * 7) + 13);
   // Clot + Lucky
-  result.clotLucky = cookieInfo.clotLucky.odds[wrathValue] * (Math.min(bankAmount * 0.1, cps * 60 * 20 * 0.5) + 13);
+  result.clotLucky = cookieInfo.clotLucky.odds[wrathValue] * (Math.min(bankAmount * 0.15, cps * 60 * 15 * 0.5) + 13);
   // Click
   result.click = cookieInfo.click.odds[wrathValue] * frenzyCps * luckyMod * 13 * 777;
   // Frenzy + Click
@@ -633,11 +633,11 @@ function estimatedTimeRemaining(cookies) {
 }
 
 function luckyBank() {
-  return baseCps() * 60 * 20 * 10;
+  return baseCps() * 60 * 100;
 }
 
 function luckyFrenzyBank() {
-  return baseCps() * 60 * 20 * 7 * 10;
+  return baseCps() * 60 * 100 * 7;
 }
 
 function chainBank() {
@@ -696,20 +696,24 @@ function weightedCookieValue(useCurrent) {
     base_golden += rollingEstimate * 0.0033;
     base_wrath += rollingEstimate * 0.0595;
   }
-  if (useCurrent && Game.cookies < maxLuckyValue() * 10) {
+  if (useCurrent && Game.cookies < maxLuckyBank()) {
     if (lucky_mod) {
-      base_golden -= ((1200 * cps) - Math.min(1200 * cps, Game.cookies * 0.1)) * 0.49 * 0.5 + (maxLuckyValue() - (Game.cookies * 0.1)) * 0.49 * 0.5;
+      base_golden -= ((900 * cps) - Math.min(900 * cps, Game.cookies * 0.15)) * 0.49 * 0.5 + (maxLuckyValue() - (Game.cookies * 0.15)) * 0.49 * 0.5;
     } else {
-      base_golden -= (maxLuckyValue() - (Game.cookies * 0.1)) * 0.49;
-      base_wrath  -= (maxLuckyValue() - (Game.cookies * 0.1)) * 0.29;
+      base_golden -= (maxLuckyValue() - (Game.cookies * 0.15)) * 0.49;
+      base_wrath  -= (maxLuckyValue() - (Game.cookies * 0.15)) * 0.29;
     }
   }
   return Game.elderWrath / 3.0 * base_wrath + (3 - Game.elderWrath) / 3.0 * base_golden;
 }
 
 function maxLuckyValue() {
-  var gcMod = Game.Has('Get lucky') ? 8400 : 1200;
+  var gcMod = Game.Has('Get lucky') ? 6300 : 900;
   return baseCps() * gcMod;
+}
+
+function maxLuckyBank() {
+  return  Game.Has('Get lucky') ? luckyFrenzyBank() : luckyBank();
 }
 
 function maxCookieTime() {


### PR DESCRIPTION
This includes achappell's commit for 2.002 fixes, as well as vizzie-tx's Dragonflight fixes.

Additional fixes for 2.002:

- Auto-buying of Santa upgrades was broken
- Lucky GC calc was changed (max value was reduced by 25%, max bank was reduced by 50%)
- New buffs were screwing up the base CPS calc, sometimes causing the lucky bank to be abandoned

Improvements:

- Delta-CPS display for GC Bank targets now compares to current bank (much more intuitive and informative).  Calculations are not affected.
- Autofrenzy now active during new Cursed Finger buff.

Open issue: While vizzie-tx added Dragonflight to both the autofrenzy setting and the click-value calc, Cursed Finger is not yet included in the click-value calc.